### PR TITLE
Dont expose ISidedInventory for TilesEntities

### DIFF
--- a/src/main/java/appeng/block/misc/BlockCharger.java
+++ b/src/main/java/appeng/block/misc/BlockCharger.java
@@ -110,7 +110,7 @@ public class BlockCharger extends AEBaseTileBlock implements ICustomCollision
 		{
 			final TileCharger tc = (TileCharger) tile;
 
-			if( AEApi.instance().definitions().materials().certusQuartzCrystalCharged().isSameAs( tc.getStackInSlot( 0 ) ) )
+			if( AEApi.instance().definitions().materials().certusQuartzCrystalCharged().isSameAs( tc.getInternalInventory().getStackInSlot( 0 ) ) )
 			{
 				final double xOff = 0.0;
 				final double yOff = 0.0;
@@ -201,7 +201,7 @@ public class BlockCharger extends AEBaseTileBlock implements ICustomCollision
 	{
 		Matrix4f transform = new Matrix4f();
 		transform.translate( new Vector3f( 0.5f, 0.4f, 0.5f ) );
-		return new ImmutablePair<>( tile.getStackInSlot( 0 ), transform );
+		return new ImmutablePair<>( tile.getInternalInventory().getStackInSlot( 0 ), transform );
 	}
 
 }

--- a/src/main/java/appeng/block/storage/BlockChest.java
+++ b/src/main/java/appeng/block/storage/BlockChest.java
@@ -109,7 +109,7 @@ public class BlockChest extends AEBaseTileBlock
 			}
 			else
 			{
-				final ItemStack cell = tg.getStackInSlot( 1 );
+				final ItemStack cell = tg.getInternalInventory().getStackInSlot( 1 );
 				if( cell != null )
 				{
 					final ICellHandler ch = AEApi.instance().registries().cell().getHandler( cell );

--- a/src/main/java/appeng/client/render/tesr/InscriberTESR.java
+++ b/src/main/java/appeng/client/render/tesr/InscriberTESR.java
@@ -3,6 +3,8 @@ package appeng.client.render.tesr;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
+import net.minecraft.inventory.IInventory;
+
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.block.Block;
@@ -133,16 +135,18 @@ public class InscriberTESR extends TileEntitySpecialRenderer<TileInscriber>
 		// render items.
 		GlStateManager.color( 1.0F, 1.0F, 1.0F, 1.0F );
 
+		IInventory inv = tile.getInternalInventory();
+		
 		int items = 0;
-		if( !tile.getStackInSlot( 0 ).isEmpty() )
+		if( !inv.getStackInSlot( 0 ).isEmpty() )
 		{
 			items++;
 		}
-		if( !tile.getStackInSlot( 1 ).isEmpty() )
+		if( !inv.getStackInSlot( 1 ).isEmpty() )
 		{
 			items++;
 		}
-		if( !tile.getStackInSlot( 2 ).isEmpty() )
+		if( !inv.getStackInSlot( 2 ).isEmpty() )
 		{
 			items++;
 		}
@@ -151,7 +155,7 @@ public class InscriberTESR extends TileEntitySpecialRenderer<TileInscriber>
 
 		if( relativeProgress > 1.0f || items == 0 )
 		{
-			ItemStack is = tile.getStackInSlot( 3 );
+			ItemStack is = inv.getStackInSlot( 3 );
 
 			if( is.isEmpty() )
 			{
@@ -166,9 +170,9 @@ public class InscriberTESR extends TileEntitySpecialRenderer<TileInscriber>
 		}
 		else
 		{
-			this.renderItem( tile.getStackInSlot( 0 ), press, tile, buffer, x, y, z );
-			this.renderItem( tile.getStackInSlot( 1 ), -press, tile, buffer, x, y, z );
-			this.renderItem( tile.getStackInSlot( 2 ), 0.0f, tile, buffer, x, y, z );
+			this.renderItem( inv.getStackInSlot( 0 ), press, tile, buffer, x, y, z );
+			this.renderItem( inv.getStackInSlot( 1 ), -press, tile, buffer, x, y, z );
+			this.renderItem( inv.getStackInSlot( 2 ), 0.0f, tile, buffer, x, y, z );
 		}
 
 		// Tessellator.getInstance().draw();

--- a/src/main/java/appeng/container/implementations/ContainerChest.java
+++ b/src/main/java/appeng/container/implementations/ContainerChest.java
@@ -36,7 +36,7 @@ public class ContainerChest extends AEBaseContainer
 		super( ip, chest, null );
 		this.chest = chest;
 
-		this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.STORAGE_CELLS, this.chest, 1, 80, 37, this.getInventoryPlayer() ) );
+		this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.STORAGE_CELLS, this.chest.getInternalInventory(), 1, 80, 37, this.getInventoryPlayer() ) );
 
 		this.bindPlayerInventory( ip, 0, 166 - /* height of player inventory */82 );
 	}

--- a/src/main/java/appeng/container/implementations/ContainerCondenser.java
+++ b/src/main/java/appeng/container/implementations/ContainerCondenser.java
@@ -48,8 +48,8 @@ public class ContainerCondenser extends AEBaseContainer implements IProgressProv
 		super( ip, condenser, null );
 		this.condenser = condenser;
 
-		this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.TRASH, condenser, 0, 51, 52, ip ) );
-		this.addSlotToContainer( new SlotOutput( condenser, 1, 105, 52, -1 ) );
+		this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.TRASH, condenser.getInternalInventory(), 0, 51, 52, ip ) );
+		this.addSlotToContainer( new SlotOutput( condenser.getInternalInventory(), 1, 105, 52, -1 ) );
 		this.addSlotToContainer( ( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.STORAGE_COMPONENT, condenser.getInternalInventory(), 2, 101, 26, ip ) ).setStackLimit( 1 ) );
 
 		this.bindPlayerInventory( ip, 0, 197 - /* height of player inventory */82 );

--- a/src/main/java/appeng/container/implementations/ContainerDrive.java
+++ b/src/main/java/appeng/container/implementations/ContainerDrive.java
@@ -37,7 +37,7 @@ public class ContainerDrive extends AEBaseContainer
 		{
 			for( int x = 0; x < 2; x++ )
 			{
-				this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.STORAGE_CELLS, drive, x + y * 2, 71 + x * 18, 14 + y * 18, this.getInventoryPlayer() ) );
+				this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.STORAGE_CELLS, drive.getInternalInventory(), x + y * 2, 71 + x * 18, 14 + y * 18, this.getInventoryPlayer() ) );
 			}
 		}
 

--- a/src/main/java/appeng/container/implementations/ContainerGrinder.java
+++ b/src/main/java/appeng/container/implementations/ContainerGrinder.java
@@ -20,7 +20,7 @@ package appeng.container.implementations;
 
 
 import net.minecraft.entity.player.InventoryPlayer;
-
+import net.minecraft.inventory.IInventory;
 import appeng.container.AEBaseContainer;
 import appeng.container.slot.SlotInaccessible;
 import appeng.container.slot.SlotOutput;
@@ -35,15 +35,17 @@ public class ContainerGrinder extends AEBaseContainer
 	{
 		super( ip, grinder, null );
 
-		this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.ORE, grinder, 0, 12, 17, this.getInventoryPlayer() ) );
-		this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.ORE, grinder, 1, 12 + 18, 17, this.getInventoryPlayer() ) );
-		this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.ORE, grinder, 2, 12 + 36, 17, this.getInventoryPlayer() ) );
+		IInventory inv = grinder.getInternalInventory();
+		
+		this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.ORE, inv, 0, 12, 17, this.getInventoryPlayer() ) );
+		this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.ORE, inv, 1, 12 + 18, 17, this.getInventoryPlayer() ) );
+		this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.ORE, inv, 2, 12 + 36, 17, this.getInventoryPlayer() ) );
 
-		this.addSlotToContainer( new SlotInaccessible( grinder, 6, 80, 40 ) );
+		this.addSlotToContainer( new SlotInaccessible( inv, 6, 80, 40 ) );
 
-		this.addSlotToContainer( new SlotOutput( grinder, 3, 112, 63, 2 * 16 + 15 ) );
-		this.addSlotToContainer( new SlotOutput( grinder, 4, 112 + 18, 63, 2 * 16 + 15 ) );
-		this.addSlotToContainer( new SlotOutput( grinder, 5, 112 + 36, 63, 2 * 16 + 15 ) );
+		this.addSlotToContainer( new SlotOutput( inv, 3, 112, 63, 2 * 16 + 15 ) );
+		this.addSlotToContainer( new SlotOutput( inv, 4, 112 + 18, 63, 2 * 16 + 15 ) );
+		this.addSlotToContainer( new SlotOutput( inv, 5, 112 + 36, 63, 2 * 16 + 15 ) );
 
 		this.bindPlayerInventory( ip, 0, 176 - /* height of player inventory */82 );
 	}

--- a/src/main/java/appeng/container/implementations/ContainerInscriber.java
+++ b/src/main/java/appeng/container/implementations/ContainerInscriber.java
@@ -20,6 +20,7 @@ package appeng.container.implementations;
 
 
 import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
@@ -59,12 +60,14 @@ public class ContainerInscriber extends ContainerUpgradeable implements IProgres
 	{
 		super( ip, te );
 		this.ti = te;
+		
+		IInventory inv = this.ti.getInternalInventory();
 
-		this.addSlotToContainer( this.top = new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.INSCRIBER_PLATE, this.ti, 0, 45, 16, this.getInventoryPlayer() ) );
-		this.addSlotToContainer( this.bottom = new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.INSCRIBER_PLATE, this.ti, 1, 45, 62, this.getInventoryPlayer() ) );
-		this.addSlotToContainer( this.middle = new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.INSCRIBER_INPUT, this.ti, 2, 63, 39, this.getInventoryPlayer() ) );
+		this.addSlotToContainer( this.top = new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.INSCRIBER_PLATE, inv, 0, 45, 16, this.getInventoryPlayer() ) );
+		this.addSlotToContainer( this.bottom = new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.INSCRIBER_PLATE, inv, 1, 45, 62, this.getInventoryPlayer() ) );
+		this.addSlotToContainer( this.middle = new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.INSCRIBER_INPUT, inv, 2, 63, 39, this.getInventoryPlayer() ) );
 
-		this.addSlotToContainer( new SlotOutput( this.ti, 3, 113, 40, -1 ) );
+		this.addSlotToContainer( new SlotOutput( inv, 3, 113, 40, -1 ) );
 	}
 
 	@Override
@@ -108,8 +111,8 @@ public class ContainerInscriber extends ContainerUpgradeable implements IProgres
 	@Override
 	public boolean isValidForSlot( final Slot s, final ItemStack is )
 	{
-		final ItemStack top = this.ti.getStackInSlot( 0 );
-		final ItemStack bot = this.ti.getStackInSlot( 1 );
+		final ItemStack top = this.ti.getInternalInventory().getStackInSlot( 0 );
+		final ItemStack bot = this.ti.getInternalInventory().getStackInSlot( 1 );
 
 		if( s == this.middle )
 		{

--- a/src/main/java/appeng/container/implementations/ContainerQNB.java
+++ b/src/main/java/appeng/container/implementations/ContainerQNB.java
@@ -33,7 +33,7 @@ public class ContainerQNB extends AEBaseContainer
 	{
 		super( ip, quantumBridge, null );
 
-		this.addSlotToContainer( ( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.QE_SINGULARITY, quantumBridge, 0, 80, 37, this.getInventoryPlayer() ) ).setStackLimit( 1 ) );
+		this.addSlotToContainer( ( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.QE_SINGULARITY, quantumBridge.getInternalInventory(), 0, 80, 37, this.getInventoryPlayer() ) ).setStackLimit( 1 ) );
 
 		this.bindPlayerInventory( ip, 0, 166 - /* height of player inventory */82 );
 	}

--- a/src/main/java/appeng/container/implementations/ContainerSkyChest.java
+++ b/src/main/java/appeng/container/implementations/ContainerSkyChest.java
@@ -41,11 +41,11 @@ public class ContainerSkyChest extends AEBaseContainer
 		{
 			for( int x = 0; x < 9; x++ )
 			{
-				this.addSlotToContainer( new SlotNormal( this.chest, y * 9 + x, 8 + 18 * x, 24 + 18 * y ) );
+				this.addSlotToContainer( new SlotNormal( this.chest.getInternalInventory(), y * 9 + x, 8 + 18 * x, 24 + 18 * y ) );
 			}
 		}
 
-		this.chest.openInventory( ip.player );
+		this.chest.getInternalInventory().openInventory( ip.player );
 
 		this.bindPlayerInventory( ip, 0, 195 - /* height of player inventory */82 );
 	}
@@ -54,6 +54,6 @@ public class ContainerSkyChest extends AEBaseContainer
 	public void onContainerClosed( final EntityPlayer par1EntityPlayer )
 	{
 		super.onContainerClosed( par1EntityPlayer );
-		this.chest.closeInventory( par1EntityPlayer );
+		this.chest.getInternalInventory().closeInventory( par1EntityPlayer );
 	}
 }

--- a/src/main/java/appeng/container/implementations/ContainerSpatialIOPort.java
+++ b/src/main/java/appeng/container/implementations/ContainerSpatialIOPort.java
@@ -57,8 +57,8 @@ public class ContainerSpatialIOPort extends AEBaseContainer
 			this.network = spatialIOPort.getGridNode( AEPartLocation.INTERNAL ).getGrid();
 		}
 
-		this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.SPATIAL_STORAGE_CELLS, spatialIOPort, 0, 52, 48, this.getInventoryPlayer() ) );
-		this.addSlotToContainer( new SlotOutput( spatialIOPort, 1, 113, 48, SlotRestrictedInput.PlacableItemType.SPATIAL_STORAGE_CELLS.IIcon ) );
+		this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.SPATIAL_STORAGE_CELLS, spatialIOPort.getInternalInventory(), 0, 52, 48, this.getInventoryPlayer() ) );
+		this.addSlotToContainer( new SlotOutput( spatialIOPort.getInternalInventory(), 1, 113, 48, SlotRestrictedInput.PlacableItemType.SPATIAL_STORAGE_CELLS.IIcon ) );
 
 		this.bindPlayerInventory( ip, 0, 197 - /* height of player inventory */82 );
 	}

--- a/src/main/java/appeng/container/implementations/ContainerVibrationChamber.java
+++ b/src/main/java/appeng/container/implementations/ContainerVibrationChamber.java
@@ -45,7 +45,7 @@ public class ContainerVibrationChamber extends AEBaseContainer implements IProgr
 		super( ip, vibrationChamber, null );
 		this.vibrationChamber = vibrationChamber;
 
-		this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.FUEL, vibrationChamber, 0, 80, 37, this.getInventoryPlayer() ) );
+		this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.FUEL, vibrationChamber.getInternalInventory(), 0, 80, 37, this.getInventoryPlayer() ) );
 
 		this.bindPlayerInventory( ip, 0, 166 - /* height of player inventory */82 );
 	}

--- a/src/main/java/appeng/container/implementations/ContainerWireless.java
+++ b/src/main/java/appeng/container/implementations/ContainerWireless.java
@@ -43,7 +43,7 @@ public class ContainerWireless extends AEBaseContainer
 		super( ip, te, null );
 		this.wirelessTerminal = te;
 
-		this.addSlotToContainer( this.boosterSlot = new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.RANGE_BOOSTER, this.wirelessTerminal, 0, 80, 47, this.getInventoryPlayer() ) );
+		this.addSlotToContainer( this.boosterSlot = new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.RANGE_BOOSTER, this.wirelessTerminal.getInternalInventory(), 0, 80, 47, this.getInventoryPlayer() ) );
 
 		this.bindPlayerInventory( ip, 0, 166 - /* height of player inventory */82 );
 	}

--- a/src/main/java/appeng/tile/AEBaseInvTile.java
+++ b/src/main/java/appeng/tile/AEBaseInvTile.java
@@ -23,8 +23,9 @@ import java.util.EnumMap;
 
 import javax.annotation.Nullable;
 
-import net.minecraft.block.Block;
-import net.minecraft.entity.player.EntityPlayer;
+import appeng.tile.events.TileEventType;
+import appeng.tile.inventory.IAEAppEngInventory;
+import appeng.tile.inventory.InvOperation;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
@@ -39,24 +40,13 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.wrapper.InvWrapper;
 import net.minecraftforge.items.wrapper.SidedInvWrapper;
 
-import appeng.block.AEBaseBlock;
-import appeng.tile.events.TileEventType;
-import appeng.tile.inventory.IAEAppEngInventory;
-import appeng.tile.inventory.InvOperation;
 
-
-public abstract class AEBaseInvTile extends AEBaseTile implements ISidedInventory, IAEAppEngInventory
+public abstract class AEBaseInvTile extends AEBaseTile implements IAEAppEngInventory
 {
 
 	private EnumMap<EnumFacing, IItemHandler> sidedItemHandler = new EnumMap<>( EnumFacing.class );
 
 	private IItemHandler itemHandler;
-
-	@Override
-	public String getName()
-	{
-		return this.getCustomName();
-	}
 
 	@TileEvent( TileEventType.WORLD_NBT_READ )
 	public void readFromNBT_AEBaseInvTile( final net.minecraft.nbt.NBTTagCompound data )
@@ -80,7 +70,7 @@ public abstract class AEBaseInvTile extends AEBaseTile implements ISidedInventor
 		for( int x = 0; x < inv.getSizeInventory(); x++ )
 		{
 			final NBTTagCompound item = new NBTTagCompound();
-			final ItemStack is = this.getStackInSlot( x );
+			final ItemStack is = inv.getStackInSlot( x );
 			if( !is.isEmpty() )
 			{
 				is.writeToNBT( item );
@@ -90,35 +80,6 @@ public abstract class AEBaseInvTile extends AEBaseTile implements ISidedInventor
 		data.setTag( "inv", opt );
 	}
 
-	@Override
-	public int getSizeInventory()
-	{
-		return this.getInternalInventory().getSizeInventory();
-	}
-
-	@Override
-	public ItemStack getStackInSlot( final int i )
-	{
-		return this.getInternalInventory().getStackInSlot( i );
-	}
-
-	@Override
-	public ItemStack decrStackSize( final int i, final int j )
-	{
-		return this.getInternalInventory().decrStackSize( i, j );
-	}
-
-	@Override
-	public ItemStack removeStackFromSlot( final int i )
-	{
-		return ItemStack.EMPTY;
-	}
-
-	@Override
-	public void setInventorySlotContents( final int i, @Nullable final ItemStack itemstack )
-	{
-		this.getInternalInventory().setInventorySlotContents( i, itemstack );
-	}
 
 	/**
 	 * Returns if the inventory is named
@@ -130,88 +91,7 @@ public abstract class AEBaseInvTile extends AEBaseTile implements ISidedInventor
 	}
 
 	@Override
-	public int getInventoryStackLimit()
-	{
-		return 64;
-	}
-
-	@Override
-	public boolean isUsableByPlayer( final EntityPlayer p )
-	{
-		final double squaredMCReach = 64.0D;
-
-		return this.world.getTileEntity( this.pos ) == this && p.getDistanceSq( this.pos.getX() + 0.5D, this.pos.getY() + 0.5D, this.pos.getZ() + 0.5D ) <= squaredMCReach;
-	}
-
-	@Override
-	public void openInventory( final EntityPlayer player )
-	{
-
-	}
-
-	;
-
-	@Override
-	public void closeInventory( final EntityPlayer player )
-	{
-
-	}
-
-	@Override
-	public boolean isItemValidForSlot( final int i, final ItemStack itemstack )
-	{
-		return true;
-	}
-
-	@Override
 	public abstract void onChangeInventory( IInventory inv, int slot, InvOperation mc, ItemStack removed, ItemStack added );
-
-	@Override
-	public int[] getSlotsForFace( final EnumFacing side )
-	{
-		final Block blk = this.world.getBlockState( this.pos ).getBlock();
-		if( blk instanceof AEBaseBlock )
-		{
-			return this.getAccessibleSlotsBySide( ( (AEBaseBlock) blk ).mapRotation( this, side ) );
-		}
-		return this.getAccessibleSlotsBySide( side );
-	}
-
-	@Override
-	public boolean canInsertItem( final int slotIndex, final ItemStack insertingItem, final EnumFacing side )
-	{
-		return this.isItemValidForSlot( slotIndex, insertingItem );
-	}
-
-	@Override
-	public boolean canExtractItem( final int slotIndex, final ItemStack extractedItem, final EnumFacing side )
-	{
-		return true;
-	}
-
-	@Override
-	public void clear()
-	{
-		this.getInternalInventory().clear();
-	}
-
-	@Override
-	public int getField( final int id )
-	{
-		return 0;
-	}
-
-	@Override
-	public void setField( final int id, final int value )
-	{
-
-	}
-
-	@Override
-	public int getFieldCount()
-	{
-		return 0;
-	}
 
 	@Override
 	public ITextComponent getDisplayName()
@@ -223,7 +103,7 @@ public abstract class AEBaseInvTile extends AEBaseTile implements ISidedInventor
 		return new TextComponentTranslation( this.getBlockType().getUnlocalizedName() );
 	}
 
-	public abstract int[] getAccessibleSlotsBySide( EnumFacing whichSide );
+	
 
 	@Override
 	public boolean hasCapability( Capability<?> capability, EnumFacing facing )
@@ -237,20 +117,24 @@ public abstract class AEBaseInvTile extends AEBaseTile implements ISidedInventor
 	{
 		if( capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY )
 		{
-			if( facing == null )
+			IInventory inv = getInternalInventory();
+			
+			if( facing == null || !(inv instanceof ISidedInventory))
 			{
 				if( itemHandler == null )
 				{
-					itemHandler = new InvWrapper( getInternalInventory() );
+					itemHandler = new InvWrapper( inv );
 				}
 				return (T) itemHandler;
 			}
 			else
 			{
-				return (T) sidedItemHandler.computeIfAbsent( facing, side -> new SidedInvWrapper( this, side ) );
+				return (T) sidedItemHandler.computeIfAbsent( facing, side -> new SidedInvWrapper( (ISidedInventory) inv , side ) );
 			}
 		}
 		return super.getCapability( capability, facing );
 	}
 
+	
+	public abstract int[] getAccessibleSlotsBySide( EnumFacing whichSide );
 }

--- a/src/main/java/appeng/tile/grid/AENetworkInvTile.java
+++ b/src/main/java/appeng/tile/grid/AENetworkInvTile.java
@@ -19,8 +19,6 @@
 package appeng.tile.grid;
 
 
-import net.minecraft.nbt.NBTTagCompound;
-
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.util.AEPartLocation;
@@ -29,6 +27,7 @@ import appeng.me.helpers.IGridProxyable;
 import appeng.tile.AEBaseInvTile;
 import appeng.tile.TileEvent;
 import appeng.tile.events.TileEventType;
+import net.minecraft.nbt.NBTTagCompound;
 
 
 public abstract class AENetworkInvTile extends AEBaseInvTile implements IActionHost, IGridProxyable
@@ -99,17 +98,4 @@ public abstract class AENetworkInvTile extends AEBaseInvTile implements IActionH
 	{
 		return this.getProxy().getNode();
 	}
-
-	@Override
-	public int getField( final int id )
-	{
-		return 0;
-	}
-
-	@Override
-	public int getFieldCount()
-	{
-		return 0;
-	}
-
 }

--- a/src/main/java/appeng/tile/inventory/AppEngInternalInventory.java
+++ b/src/main/java/appeng/tile/inventory/AppEngInternalInventory.java
@@ -21,15 +21,14 @@ package appeng.tile.inventory;
 
 import java.util.Iterator;
 
+import appeng.core.AELog;
+import appeng.util.Platform;
+import appeng.util.iterators.InvIterator;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.text.ITextComponent;
-
-import appeng.core.AELog;
-import appeng.util.Platform;
-import appeng.util.iterators.InvIterator;
 
 
 public class AppEngInternalInventory implements IInventory, Iterable<ItemStack>
@@ -40,14 +39,19 @@ public class AppEngInternalInventory implements IInventory, Iterable<ItemStack>
 	private IAEAppEngInventory te;
 	private int maxStack;
 
-	public AppEngInternalInventory( final IAEAppEngInventory inventory, final int size )
+	public AppEngInternalInventory( final IAEAppEngInventory inventory, final int size, final int maxStack )
 	{
 		this.setTileEntity( inventory );
 		this.size = size;
-		this.maxStack = 64;
+		this.maxStack = maxStack;
 		this.inv = new ItemStack[size];
 	}
 
+	public AppEngInternalInventory( final IAEAppEngInventory inventory, final int size ) 
+	{
+		this(inventory, size, 64);
+	}
+	
 	public boolean isEmpty()
 	{
 		for( int x = 0; x < this.size; x++ )
@@ -327,7 +331,7 @@ public class AppEngInternalInventory implements IInventory, Iterable<ItemStack>
 		this.enableClientEvents = enableClientEvents;
 	}
 
-	private IAEAppEngInventory getTileEntity()
+	protected IAEAppEngInventory getTileEntity()
 	{
 		return this.te;
 	}

--- a/src/main/java/appeng/tile/inventory/AppEngInternalSidedInventory.java
+++ b/src/main/java/appeng/tile/inventory/AppEngInternalSidedInventory.java
@@ -1,0 +1,47 @@
+package appeng.tile.inventory;
+
+import appeng.block.AEBaseBlock;
+import appeng.tile.AEBaseInvTile;
+import net.minecraft.block.Block;
+import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
+
+
+public class AppEngInternalSidedInventory extends AppEngInternalInventory implements ISidedInventory 
+{
+	public AppEngInternalSidedInventory( final AEBaseInvTile inventory, final int size, final int maxStack )
+	{
+		super(inventory, size, maxStack);
+	}
+
+	public AppEngInternalSidedInventory( final AEBaseInvTile inventory, final int size ) 
+	{
+		super(inventory, size);
+	}
+
+	@Override
+	public int[] getSlotsForFace(EnumFacing side) 
+	{
+		AEBaseInvTile te = (AEBaseInvTile)getTileEntity();
+		
+		final Block blk = te.getBlockState().getBlock();
+		if( blk instanceof AEBaseBlock )
+		{
+			return te.getAccessibleSlotsBySide( ( (AEBaseBlock) blk ).mapRotation( te, side ) );
+		}			
+		return te.getAccessibleSlotsBySide( side );	
+	}
+
+	@Override
+	public boolean canInsertItem(int slotIndex, ItemStack insertingItem, EnumFacing direction) 
+	{
+		return this.isItemValidForSlot( slotIndex, insertingItem );
+	}
+
+	@Override
+	public boolean canExtractItem(int index, ItemStack stack, EnumFacing direction) 
+	{
+		return true;
+	}
+}

--- a/src/main/java/appeng/tile/misc/TileInterface.java
+++ b/src/main/java/appeng/tile/misc/TileInterface.java
@@ -26,18 +26,6 @@ import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableSet;
 
-import io.netty.buffer.ByteBuf;
-
-import net.minecraft.inventory.IInventory;
-import net.minecraft.inventory.InventoryCrafting;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
-import net.minecraftforge.common.capabilities.Capability;
-
 import appeng.api.config.Actionable;
 import appeng.api.config.Upgrades;
 import appeng.api.networking.IGridNode;
@@ -64,6 +52,16 @@ import appeng.tile.grid.AENetworkInvTile;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.Platform;
 import appeng.util.inv.IInventoryDestination;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.common.capabilities.Capability;
 
 
 public class TileInterface extends AENetworkInvTile implements IGridTickable, IInventoryDestination, IInterfaceHost, IPriorityHost
@@ -360,12 +358,5 @@ public class TileInterface extends AENetworkInvTile implements IGridTickable, II
 			return result;
 		}
 		return super.getCapability( capability, facing );
-	}
-
-	@Override
-	public boolean isEmpty()
-	{
-		// TODO Auto-generated method stub
-		return false;
 	}
 }

--- a/src/main/java/appeng/tile/networking/TileController.java
+++ b/src/main/java/appeng/tile/networking/TileController.java
@@ -21,11 +21,6 @@ package appeng.tile.networking;
 
 import java.util.EnumSet;
 
-import net.minecraft.inventory.IInventory;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.math.BlockPos;
-
 import appeng.api.config.Actionable;
 import appeng.api.networking.GridFlags;
 import appeng.api.networking.events.MENetworkControllerChange;
@@ -41,7 +36,15 @@ import appeng.block.networking.BlockController.ControllerBlockState;
 import appeng.me.GridAccessException;
 import appeng.tile.grid.AENetworkPowerTile;
 import appeng.tile.inventory.AppEngInternalInventory;
+import appeng.tile.inventory.AppEngInternalSidedInventory;
 import appeng.tile.inventory.InvOperation;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 
 public class TileController extends AENetworkPowerTile
@@ -210,6 +213,15 @@ public class TileController extends AENetworkPowerTile
 	{
 		return ACCESSIBLE_SLOTS_BY_SIDE;
 	}
+	
+	@Override
+	public boolean hasCapability( Capability<?> capability, EnumFacing facing )
+	{
+		if ( capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY )
+			return false;
+		
+		return super.hasCapability( capability, facing );
+	}
 
 	/**
 	 * Check for a controller at this coordinates as well as is it loaded.
@@ -224,13 +236,6 @@ public class TileController extends AENetworkPowerTile
 			return this.world.getTileEntity( pos ) instanceof TileController;
 		}
 
-		return false;
-	}
-
-	@Override
-	public boolean isEmpty()
-	{
-		// TODO Auto-generated method stub
 		return false;
 	}
 }

--- a/src/main/java/appeng/tile/networking/TileEnergyAcceptor.java
+++ b/src/main/java/appeng/tile/networking/TileEnergyAcceptor.java
@@ -19,11 +19,6 @@
 package appeng.tile.networking;
 
 
-import net.minecraft.inventory.IInventory;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.EnumFacing;
-
 import appeng.api.config.Actionable;
 import appeng.api.networking.energy.IEnergyGrid;
 import appeng.api.util.AECableType;
@@ -31,7 +26,15 @@ import appeng.api.util.AEPartLocation;
 import appeng.me.GridAccessException;
 import appeng.tile.grid.AENetworkPowerTile;
 import appeng.tile.inventory.AppEngInternalInventory;
+import appeng.tile.inventory.AppEngInternalSidedInventory;
 import appeng.tile.inventory.InvOperation;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 
 public class TileEnergyAcceptor extends AENetworkPowerTile
@@ -108,6 +111,16 @@ public class TileEnergyAcceptor extends AENetworkPowerTile
 	}
 
 	@Override
+	public boolean hasCapability( Capability<?> capability, EnumFacing facing )
+	{
+		if ( capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY )
+			return false;
+		
+		return super.hasCapability( capability, facing );
+	}
+
+	
+	@Override
 	public void onChangeInventory( final IInventory inv, final int slot, final InvOperation mc, final ItemStack removed, final ItemStack added )
 	{
 
@@ -118,12 +131,4 @@ public class TileEnergyAcceptor extends AENetworkPowerTile
 	{
 		return this.sides;
 	}
-
-	@Override
-	public boolean isEmpty()
-	{
-		// TODO Auto-generated method stub
-		return false;
-	}
-
 }

--- a/src/main/java/appeng/tile/networking/TileWireless.java
+++ b/src/main/java/appeng/tile/networking/TileWireless.java
@@ -21,12 +21,6 @@ package appeng.tile.networking;
 
 import java.util.EnumSet;
 
-import io.netty.buffer.ByteBuf;
-
-import net.minecraft.inventory.IInventory;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.EnumFacing;
-
 import appeng.api.AEApi;
 import appeng.api.implementations.IPowerChannelState;
 import appeng.api.implementations.tiles.IWirelessAccessPoint;
@@ -44,8 +38,14 @@ import appeng.tile.TileEvent;
 import appeng.tile.events.TileEventType;
 import appeng.tile.grid.AENetworkInvTile;
 import appeng.tile.inventory.AppEngInternalInventory;
+import appeng.tile.inventory.AppEngInternalSidedInventory;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.Platform;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
 
 
 public class TileWireless extends AENetworkInvTile implements IWirelessAccessPoint, IPowerChannelState
@@ -55,7 +55,15 @@ public class TileWireless extends AENetworkInvTile implements IWirelessAccessPoi
 	public static final int CHANNEL_FLAG = 2;
 
 	private final int[] sides = { 0 };
-	private final AppEngInternalInventory inv = new AppEngInternalInventory( this, 1 );
+	private final AppEngInternalInventory inv = new AppEngInternalInventory( this, 1 )
+	{
+		@Override
+		public boolean isItemValidForSlot( final int i, final ItemStack itemstack )
+		{
+			return AEApi.instance().definitions().materials().wirelessBooster().isSameAs( itemstack );
+		}
+
+	};
 
 	private int clientFlags = 0;
 
@@ -136,11 +144,6 @@ public class TileWireless extends AENetworkInvTile implements IWirelessAccessPoi
 		return this.inv;
 	}
 
-	@Override
-	public boolean isItemValidForSlot( final int i, final ItemStack itemstack )
-	{
-		return AEApi.instance().definitions().materials().wirelessBooster().isSameAs( itemstack );
-	}
 
 	@Override
 	public void onChangeInventory( final IInventory inv, final int slot, final InvOperation mc, final ItemStack removed, final ItemStack added )
@@ -222,12 +225,5 @@ public class TileWireless extends AENetworkInvTile implements IWirelessAccessPoi
 	private void setClientFlags( final int clientFlags )
 	{
 		this.clientFlags = clientFlags;
-	}
-
-	@Override
-	public boolean isEmpty()
-	{
-		// TODO Auto-generated method stub
-		return false;
 	}
 }

--- a/src/main/java/appeng/tile/qnb/TileQuantumBridge.java
+++ b/src/main/java/appeng/tile/qnb/TileQuantumBridge.java
@@ -22,16 +22,6 @@ package appeng.tile.qnb;
 import java.util.EnumSet;
 import java.util.Optional;
 
-import io.netty.buffer.ByteBuf;
-
-import net.minecraft.block.Block;
-import net.minecraft.inventory.IInventory;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.ITickable;
-
 import appeng.api.AEApi;
 import appeng.api.definitions.IBlockDefinition;
 import appeng.api.networking.GridFlags;
@@ -49,8 +39,18 @@ import appeng.tile.TileEvent;
 import appeng.tile.events.TileEventType;
 import appeng.tile.grid.AENetworkInvTile;
 import appeng.tile.inventory.AppEngInternalInventory;
+import appeng.tile.inventory.AppEngInternalSidedInventory;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.Platform;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.block.Block;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ITickable;
 
 
 public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock, ITickable
@@ -58,7 +58,7 @@ public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 	private final byte corner = 16;
 	private final int[] sidesRing = {};
 	private final int[] sidesLink = { 0 };
-	private final AppEngInternalInventory internalInventory = new AppEngInternalInventory( this, 1 );
+	private final AppEngInternalInventory internalInventory = new AppEngInternalInventory( this, 1, 1 );
 	private final byte hasSingularity = 32;
 	private final byte powered = 64;
 
@@ -72,7 +72,6 @@ public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 		this.getProxy().setValidSides( EnumSet.noneOf( EnumFacing.class ) );
 		this.getProxy().setFlags( GridFlags.DENSE_CAPACITY );
 		this.getProxy().setIdlePowerUsage( 22 );
-		this.internalInventory.setMaxStackSize( 1 );
 	}
 
 	@Override
@@ -94,7 +93,7 @@ public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 	{
 		int out = this.constructed;
 
-		if( !this.getStackInSlot( 0 ).isEmpty() && this.constructed != -1 )
+		if( !internalInventory.getStackInSlot( 0 ).isEmpty() && this.constructed != -1 )
 		{
 			out |= this.hasSingularity;
 		}
@@ -344,12 +343,5 @@ public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 	public byte getCorner()
 	{
 		return this.corner;
-	}
-
-	@Override
-	public boolean isEmpty()
-	{
-		// TODO Auto-generated method stub
-		return false;
 	}
 }

--- a/src/main/java/appeng/tile/storage/TileDrive.java
+++ b/src/main/java/appeng/tile/storage/TileDrive.java
@@ -23,13 +23,6 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import io.netty.buffer.ByteBuf;
-
-import net.minecraft.inventory.IInventory;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.EnumFacing;
-
 import appeng.api.AEApi;
 import appeng.api.implementations.tiles.IChestOrDrive;
 import appeng.api.networking.GridFlags;
@@ -56,8 +49,15 @@ import appeng.tile.TileEvent;
 import appeng.tile.events.TileEventType;
 import appeng.tile.grid.AENetworkInvTile;
 import appeng.tile.inventory.AppEngInternalInventory;
+import appeng.tile.inventory.AppEngInternalSidedInventory;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.Platform;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
 
 
 public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPriorityHost
@@ -68,7 +68,14 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
 	private static final int BIT_STATE_MASK = 0xDB6DB6DB;
 
 	private final int[] sides = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-	private final AppEngInternalInventory inv = new AppEngInternalInventory( this, 10 );
+	private final AppEngInternalInventory inv = new AppEngInternalInventory( this, 10 )
+	{
+		@Override
+		public boolean isItemValidForSlot( final int i, final ItemStack itemstack )
+		{
+			return !itemstack.isEmpty() && AEApi.instance().registries().cell().isCellHandled( itemstack );
+		}
+	};
 	private final ICellHandler[] handlersBySlot = new ICellHandler[10];
 	private final DriveWatcher<IAEItemStack>[] invBySlot = new DriveWatcher[10];
 	private final BaseActionSource mySrc;
@@ -262,11 +269,6 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
 		return this.inv;
 	}
 
-	@Override
-	public boolean isItemValidForSlot( final int i, final ItemStack itemstack )
-	{
-		return !itemstack.isEmpty() && AEApi.instance().registries().cell().isCellHandled( itemstack );
-	}
 
 	@Override
 	public void onChangeInventory( final IInventory inv, final int slot, final InvOperation mc, final ItemStack removed, final ItemStack added )
@@ -408,12 +410,5 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
 	public void saveChanges( final IMEInventory cellInventory )
 	{
 		this.world.markChunkDirty( this.pos, this );
-	}
-
-	@Override
-	public boolean isEmpty()
-	{
-		// TODO Auto-generated method stub
-		return false;
 	}
 }


### PR DESCRIPTION
Hey,
After the comments from @yueh i thought i try to dig a bit deeper in the code. I changed the tile entities to not expose IInventory or ISidedInventory directly. The interfaces are only for internal use with getInternalInventory(). Externally only the capability is exposed.
It's very quick and dirty - just to see if its possible. It seems to work with the little testing i did. I dont know if you want to pull this, but i think in the long run it's easier to maintain just one inventory api. If you are interested i will clean this up a bit ..