### PR TITLE
Fixes creative tab leak

### DIFF
--- a/src/main/java/appeng/items/AEBaseItem.java
+++ b/src/main/java/appeng/items/AEBaseItem.java
@@ -59,7 +59,8 @@ public abstract class AEBaseItem extends Item
 	@SuppressWarnings( "unchecked" )
 	public final void getSubItems( final CreativeTabs creativeTab, final NonNullList<ItemStack> itemStacks )
 	{
-		this.getCheckedSubItems( creativeTab, itemStacks );
+		if(isInCreativeTab(creativeTab))
+			this.getCheckedSubItems( creativeTab, itemStacks );
 	}
 
 	@Override


### PR DESCRIPTION
AE2 Items are visible in every tab. To fix that, you need to check ´isInCreativeTab´.

See https://www.reddit.com/r/feedthebeast/comments/6h9z7f/psa_the_creativetab_leak_glitch/

I added the call here, seems to work.